### PR TITLE
Eac/dump stats

### DIFF
--- a/bin/review
+++ b/bin/review
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH << File.expand_path("../lib", File.dirname(__FILE__))
-require 'optionparser'
 require 'shiba/configure'
 require 'shiba/reviewer'
 require 'shiba/review/explain_diff'

--- a/bin/stats
+++ b/bin/stats
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", File.dirname(__FILE__))
+require 'optionparser'
+require 'shiba'
+require 'shiba/stats/cli'
+
+cli = Shiba::Stats::CLI.new
+options = cli.options
+
+puts "Got:"
+puts options.inspect
+
+if !cli.valid?
+  $stderr.puts cli.failure
+  exit 1
+end
+
+# TODO:
+# Figure out testing
+
+cmd = ""
+if options[:host] != 'localhost'
+  if options[:proxy]
+    cmd << "ssh -o ProxyCommand='ssh -W' %h:%p #{options[:proxy]} -t #{options[:host]}"
+  else
+    cmd << "ssh #{options[:host]}"
+  end
+
+  cmd << " '#{cli.query_script}'"
+  puts cmd
+else
+  puts script
+  if !options[:script]
+    puts `#{cli.query_script}`
+  end
+end

--- a/bin/stats
+++ b/bin/stats
@@ -25,31 +25,17 @@ if options[:file]
   exit
 end
 
-script = if options[:host] != 'localhost'
-  cmd = ""
-  if options[:proxy]
-    cmd << "ssh -o ProxyCommand='ssh -W' %h:%p #{options[:proxy]} -t #{options[:host]}"
-  else
-    cmd << "ssh #{options[:host]}"
-  end
-
-  cmd << " '#{cli.query_script}'"
-  cmd
-else
-  cli.query_script
-end
-
 if options[:script]
-  puts cmd
+  puts cli.script
   exit
 end
 
-out, status = cli.run(cmd)
+out, status = cli.run(cli.script)
 if status != 0
   $stderr.puts "Error during stats import:"
   $stderr.puts out
   $stderr.puts "--- script --- "
-  $stderr.puts cmd
+  $stderr.puts cli.script
   exit 1
 end
 

--- a/bin/stats
+++ b/bin/stats
@@ -4,23 +4,22 @@ $LOAD_PATH << File.expand_path("../lib", File.dirname(__FILE__))
 require 'optionparser'
 require 'shiba'
 require 'shiba/stats/cli'
+require 'shiba/index_stats'
 
 cli = Shiba::Stats::CLI.new
 options = cli.options
 
-puts "Got:"
-puts options.inspect
+if options[:verbose]
+  puts "Options: #{options.inspect}"
+end
 
 if !cli.valid?
   $stderr.puts cli.failure
   exit 1
 end
 
-# TODO:
-# Figure out testing
-
 cmd = ""
-if options[:host] != 'localhost'
+output = if options[:host] != 'localhost'
   if options[:proxy]
     cmd << "ssh -o ProxyCommand='ssh -W' %h:%p #{options[:proxy]} -t #{options[:host]}"
   else
@@ -28,10 +27,22 @@ if options[:host] != 'localhost'
   end
 
   cmd << " '#{cli.query_script}'"
-  puts cmd
+  puts cmd if options[:verbose]
 else
-  puts script
-  if !options[:script]
-    puts `#{cli.query_script}`
+  if options[:script]
+    puts cli.query_script
+    exit
   end
+
+
+  `#{cli.query_script}`
 end
+
+records = if options[:server] == "mysql"
+  Shiba::Stats::Mysql.new.parse(output)
+else
+  Shiba::Stats::Postgres.new.parse(output)
+end
+
+index = Shiba::IndexStats.from_records(records)
+puts index.to_yaml

--- a/bin/stats
+++ b/bin/stats
@@ -19,32 +19,9 @@ if !cli.valid?
   exit 1
 end
 
-def run(command)
-  out    = nil
-  thread = nil
-
-  Open3.popen2e(command) {|_,eo,th|
-    out    = eo.readlines
-    thread = th
-  }
-
-  return out, thread.value.exitstatus
-end
-
-def to_yaml(output)
-  records = if options[:server] == "mysql"
-    Shiba::Stats::Mysql.new.parse(output)
-  else
-    Shiba::Stats::Postgres.new.parse(output)
-  end
-
-  index = Shiba::IndexStats.from_records(records)
-  index.to_yaml
-end
-
 if options[:file]
   output = File.read(options[:file])
-  puts to_yaml(output)
+  puts cli.raw_stats_to_yaml(output)
   exit
 end
 
@@ -67,7 +44,7 @@ if options[:script]
   exit
 end
 
-out, status = run(cmd)
+out, status = cli.run(cmd)
 if status != 0
   $stderr.puts "Error during stats import:"
   $stderr.puts out
@@ -76,4 +53,4 @@ if status != 0
   exit 1
 end
 
-puts to_yaml(out)
+puts cli.raw_stats_to_yaml(out)

--- a/bin/stats
+++ b/bin/stats
@@ -31,10 +31,25 @@ def run(command)
   return out, thread.value.exitstatus
 end
 
-cmd = ""
-output = nil
-output = File.read(options[:file]) if options[:file]
-output ||= if options[:host] != 'localhost'
+def to_yaml(output)
+  records = if options[:server] == "mysql"
+    Shiba::Stats::Mysql.new.parse(output)
+  else
+    Shiba::Stats::Postgres.new.parse(output)
+  end
+
+  index = Shiba::IndexStats.from_records(records)
+  index.to_yaml
+end
+
+if options[:file]
+  output = File.read(options[:file])
+  puts to_yaml(output)
+  exit
+end
+
+script = if options[:host] != 'localhost'
+  cmd = ""
   if options[:proxy]
     cmd << "ssh -o ProxyCommand='ssh -W' %h:%p #{options[:proxy]} -t #{options[:host]}"
   else
@@ -42,43 +57,23 @@ output ||= if options[:host] != 'localhost'
   end
 
   cmd << " '#{cli.query_script}'"
-
-  if options[:script]
-    puts cmd
-    exit
-  end
-
-  out, status = run(cmd)
-  if status != 0
-    $stderr.puts "Error during stats import:"
-    $stderr.puts out
-    $stderr.puts "--- script --- "
-    $stderr.puts cmd
-    exit 1
-  end
-  out
+  cmd
 else
-  if options[:script]
-    puts cli.query_script
-    exit
-  end
-
-  out, status = run(cli.query_script)
-  if status != 0
-    $stderr.puts "Error during stats import:"
-    $stderr.puts out
-    $stderr.puts "--- script --- "
-    $stderr.puts cli.query_script
-    exit 1
-  end
-  out
+  cli.query_script
 end
 
-records = if options[:server] == "mysql"
-  Shiba::Stats::Mysql.new.parse(output)
-else
-  Shiba::Stats::Postgres.new.parse(output)
+if options[:script]
+  puts cmd
+  exit
 end
 
-index = Shiba::IndexStats.from_records(records)
-puts index.to_yaml
+out, status = run(cmd)
+if status != 0
+  $stderr.puts "Error during stats import:"
+  $stderr.puts out
+  $stderr.puts "--- script --- "
+  $stderr.puts cmd
+  exit 1
+end
+
+puts to_yaml(out)

--- a/bin/stats
+++ b/bin/stats
@@ -19,7 +19,7 @@ if !cli.valid?
 end
 
 cmd = ""
-output = if options[:host] != 'localhost'
+output = File.read(options[:file]) || if options[:host] != 'localhost'
   if options[:proxy]
     cmd << "ssh -o ProxyCommand='ssh -W' %h:%p #{options[:proxy]} -t #{options[:host]}"
   else

--- a/bin/stats
+++ b/bin/stats
@@ -5,6 +5,7 @@ require 'optionparser'
 require 'shiba'
 require 'shiba/stats/cli'
 require 'shiba/index_stats'
+require 'open3'
 
 cli = Shiba::Stats::CLI.new
 options = cli.options
@@ -18,8 +19,22 @@ if !cli.valid?
   exit 1
 end
 
+def run(command)
+  out    = nil
+  thread = nil
+
+  Open3.popen2e(command) {|_,eo,th|
+    out    = eo.readlines
+    thread = th
+  }
+
+  return out, thread.value.exitstatus
+end
+
 cmd = ""
-output = File.read(options[:file]) || if options[:host] != 'localhost'
+output = nil
+output = File.read(options[:file]) if options[:file]
+output ||= if options[:host] != 'localhost'
   if options[:proxy]
     cmd << "ssh -o ProxyCommand='ssh -W' %h:%p #{options[:proxy]} -t #{options[:host]}"
   else
@@ -27,15 +42,36 @@ output = File.read(options[:file]) || if options[:host] != 'localhost'
   end
 
   cmd << " '#{cli.query_script}'"
-  puts cmd if options[:verbose]
+
+  if options[:script]
+    puts cmd
+    exit
+  end
+
+  out, status = run(cmd)
+  if status != 0
+    $stderr.puts "Error during stats import:"
+    $stderr.puts out
+    $stderr.puts "--- script --- "
+    $stderr.puts cmd
+    exit 1
+  end
+  out
 else
   if options[:script]
     puts cli.query_script
     exit
   end
 
-
-  `#{cli.query_script}`
+  out, status = run(cli.query_script)
+  if status != 0
+    $stderr.puts "Error during stats import:"
+    $stderr.puts out
+    $stderr.puts "--- script --- "
+    $stderr.puts cli.query_script
+    exit 1
+  end
+  out
 end
 
 records = if options[:server] == "mysql"

--- a/lib/shiba/connection/mysql.rb
+++ b/lib/shiba/connection/mysql.rb
@@ -1,5 +1,6 @@
 require 'mysql2'
 require 'json'
+require 'shiba/stats/mysql'
 
 module Shiba
   class Connection
@@ -13,12 +14,8 @@ module Shiba
       end
 
       def fetch_indexes
-        sql =<<-EOL
-          select * from information_schema.statistics where
-          table_schema = DATABASE()
-          order by table_name, if(index_name = 'PRIMARY', '', index_name), seq_in_index
-        EOL
-        @connection.query(sql)
+        stats = Stats::Mysql.new
+        stats.fetch_indexes
       end
 
       def analyze!

--- a/lib/shiba/connection/postgres.rb
+++ b/lib/shiba/connection/postgres.rb
@@ -1,4 +1,5 @@
 require 'pg'
+require 'shiba/stats/postgres'
 
 module Shiba
   class Connection
@@ -15,61 +16,8 @@ module Shiba
       end
 
       def fetch_indexes
-        result = query(<<-EOL
-          select
-              t.relname as table_name,
-              i.relname as index_name,
-              a.attname as column_name,
-              i.reltuples as numrows,
-              ix.indisunique as is_unique,
-              ix.indisprimary as is_primary,
-              s.n_distinct as numdistinct
-          from pg_namespace p
-          join pg_class t on t.relnamespace = p.oid
-          join pg_index ix on ix.indrelid = t.oid
-          join pg_class i on i.oid = ix.indexrelid
-          join pg_attribute a on a.attrelid = t.oid
-          left join pg_stats s on s.tablename = t.relname
-              AND s.attname = a.attname
-          where
-              p.nspname = 'public'
-              and a.attnum = ANY(ix.indkey)
-              and t.relkind = 'r'
-          order by
-              t.relname,
-              ix.indisprimary desc,
-              i.relname,
-              array_position(ix.indkey, a.attnum)
-          EOL
-        )
-        rows = result.to_a.map do |row|
-          # TBD: do better than this, have them return something objecty
-          if row['is_primary'] == "t"
-            row['index_name'] = "PRIMARY"
-            row['non_unique'] = 0
-          elsif row['is_unique']
-            row['non_unique'] = 0
-          end
-
-          if row['numdistinct'].nil?
-            # meaning the table's empty.
-            row['cardinality'] = 0
-          elsif row['numdistinct'] == 0
-            # numdistinct is 0 if there's rows in the table but all values are null
-            row['cardinality'] = 1
-          elsif row['numdistinct'] < 0
-            # postgres talks about either cardinality or selectivity (depending.  what's their heuristic?)
-            # in the same way we do in the yaml file!
-            # if less than zero, it's negative selectivity.
-            row['cardinality'] = -(row['numrows'] * row['numdistinct'])
-          else
-            row['cardinality'] = row['numdistinct']
-          end
-          row
-        end
-
-        #TODO: estimate multi-index column cardinality
-        rows
+        stats = Stats::Postgres.new
+        stats.fetch_indexes
       end
 
       def count_indexes_by_table

--- a/lib/shiba/fuzzer.rb
+++ b/lib/shiba/fuzzer.rb
@@ -26,16 +26,8 @@ module Shiba
     end
 
     def fetch_index
-      stats = Shiba::IndexStats.new
       records = connection.fetch_indexes
-      tables = {}
-      records.each do |h|
-        h.keys.each { |k| h[k.downcase] = h.delete(k) }
-        h["cardinality"] = h["cardinality"].to_i
-
-        stats.add_index_column(h['table_name'], h['index_name'], h['column_name'], h['cardinality'], h['non_unique'] == 0)
-      end
-      stats
+      Shiba::IndexStats.from_records(records)
     end
 
     private

--- a/lib/shiba/index_stats.rb
+++ b/lib/shiba/index_stats.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/hash/keys'
 module Shiba
   class IndexStats
 
+    #TODO: estimate multi-index column cardinality
     def self.from_records(records)
       stats = new
       records.each do |h|

--- a/lib/shiba/index_stats.rb
+++ b/lib/shiba/index_stats.rb
@@ -4,6 +4,17 @@ require 'active_support/core_ext/hash/keys'
 module Shiba
   class IndexStats
 
+    def self.from_records(records)
+      stats = new
+      records.each do |h|
+        h.keys.each { |k| h[k.downcase] = h.delete(k) }
+        h["cardinality"] = h["cardinality"].to_i
+
+        stats.add_index_column(h['table_name'], h['index_name'], h['column_name'], h['cardinality'], h['non_unique'] == 0)
+      end
+      stats
+    end
+
     def initialize(tables = {})
       @tables = tables
       build_from_hash!

--- a/lib/shiba/review/cli.rb
+++ b/lib/shiba/review/cli.rb
@@ -1,3 +1,5 @@
+require 'optionparser'
+
 module Shiba
   module Review
     # Builds options for interacting with the reviewer via the command line.

--- a/lib/shiba/stats/cli.rb
+++ b/lib/shiba/stats/cli.rb
@@ -87,7 +87,7 @@ module Shiba
             @user_options[:script] = true
           end
 
-          opts.on("--client CLIENT", "The client command to run, defaults to 'rails dbconsole'") do |c|
+          opts.on("--client CLIENT", "The client command to run, defaults to 'rails dbconsole'. Can use 'mysql' and 'psql'.") do |c|
             @user_options[:client] = c
           end
 

--- a/lib/shiba/stats/cli.rb
+++ b/lib/shiba/stats/cli.rb
@@ -50,6 +50,29 @@ module Shiba
         message
       end
 
+      def run(command)
+        out    = nil
+        thread = nil
+
+        Open3.popen2e(command) {|_,eo,th|
+          out    = eo.readlines
+          thread = th
+        }
+
+        return out, thread.value.exitstatus
+      end
+
+      def raw_stats_to_yaml(output)
+        records = if options[:server] == "mysql"
+          Shiba::Stats::Mysql.new.parse(output)
+        else
+          Shiba::Stats::Postgres.new.parse(output)
+        end
+
+        index = Shiba::IndexStats.from_records(records)
+        index.to_yaml
+      end
+
       # cd path/to/app
       # echo "select stats sql |"
       # rails dbconsole

--- a/lib/shiba/stats/cli.rb
+++ b/lib/shiba/stats/cli.rb
@@ -73,6 +73,27 @@ module Shiba
         index.to_yaml
       end
 
+      def script
+        if options[:host] == 'localhost'
+          return query_script
+        end
+
+        # ssh remote.host 'cd app;
+        # echo "select stats sql |"
+        # rails dbconsole'
+        cmd = ""
+        if options[:proxy]
+          cmd << "ssh -o ProxyCommand='ssh -W' %h:%p #{options[:proxy]} -t #{options[:host]}"
+        else
+          cmd << "ssh #{options[:host]}"
+        end
+
+        cmd << " '#{query_script}'"
+        cmd
+      end
+
+      protected
+
       # cd path/to/app
       # echo "select stats sql |"
       # rails dbconsole
@@ -83,8 +104,6 @@ module Shiba
         script << "#{options[:client]}"
         script
       end
-
-      protected
 
       def parser
         @parser ||= OptionParser.new do |opts|

--- a/lib/shiba/stats/cli.rb
+++ b/lib/shiba/stats/cli.rb
@@ -1,0 +1,150 @@
+module Shiba
+  module Stats
+    class CLI
+
+      attr_reader :errors
+
+      def initialize
+        @user_options = {}
+        @errors = []
+        parser.parse!
+        @options = default_options.merge(@user_options)
+      end
+
+      def options
+        @options
+      end
+
+      def valid?
+        return false if @errors.any?
+
+        require_option(:server)
+        require_option(:directory)
+
+        if ![ 'mysql', 'postgres' ].include?(options[:server])
+          error("--server must be one of 'mysql' or 'postgres', got '#{options[:server]}'")
+        end
+
+        @errors.empty?
+      end
+
+      def failure
+        return nil if @errors.empty?
+
+        message, help = @errors.first
+        message += "\n"
+        if help
+          message += "\n#{parser}"
+        end
+
+        message
+      end
+
+      protected
+
+      def parser
+        @parser ||= OptionParser.new do |opts|
+          opts.banner = "Query raw table statistics from the database. Supports gathering statistics from production"
+          opts.separator ""
+          opts.separator "Required:"
+
+          opts.on("-s","--server SERVER", "The database server. Either 'mysql' or 'postgres'") do |s|
+            @user_options[:server] = normalize_server(s)
+          end
+
+          opts.on("-d", "--directory APP_DIR", "The application directory on the server.") do |d|
+            @user_options[:directory] = d
+          end
+
+          opts.separator ""
+          opts.separator "Options:"
+
+          opts.on("-h","--host HOST", "The host to execute the statistics query from. Defaults to localhost.") do |f|
+            @user_options[:host] = f
+          end
+
+          opts.on("-e", "--environment ENVIRONMENT", "The database environment. Defaults to 'production'.") do |e|
+            @user_options[:environment] = e
+          end
+
+          opts.on("--script", "Print a customizable script instead of executing.") do
+            @user_options[:script] = true
+          end
+
+          opts.on("--client CLIENT", "The client command to run, defaults to 'rails dbconsole'") do |c|
+            @user_options[:client] = c
+          end
+
+          opts.separator ""
+          opts.separator "SSH connection options:"
+
+          opts.on("-p", "--proxy PROXY_HOST", "The proxy (jump server) to connect to first.") do |p|
+            @user_options[:proxy] = p
+          end
+
+          opts.separator ""
+          opts.separator "Common options:"
+
+          opts.on("--verbose", "Verbose/debug mode") do
+            @user_options[:verbose] = true
+          end
+
+          opts.on_tail("--help", "Show this message") do
+            puts opts
+            exit
+          end
+
+          opts.on_tail("--version", "Show version") do
+            require 'shiba/version'
+            puts Shiba::VERSION
+            exit
+          end
+        end
+      end
+
+      def default_options
+        env = @user_options[:environment] || 'production'
+        { host: "localhost",
+          client: "rails dbconsole -p -e #{env}",
+          environment: env }
+      end
+
+      # cd path/to/app
+      # echo "select stats sql |"
+      # rails dbconsole
+      def query_script
+        script = ""
+        script = "cd #{options[:directory]};\n" if options[:directory]
+        script << "echo \"#{stats_sql.strip}\" |\n"
+        script << "#{options[:client]}"
+        script
+      end
+
+      def normalize_server(name)
+        case name
+        when "postgresql" then "postgres"
+        when "p"          then "postgres"
+        when "m"          then "mysql"
+        else
+          name
+        end
+      end
+
+      def require_option(name, description: nil)
+        return true if options.key?(name)
+        msg = "Required: '#{name}'"
+        msg << ". #{description}" if description
+        error(msg, help: true)
+      end
+
+      def report(message)
+        $stderr.puts message if @user_options["verbose"]
+      end
+
+      def error(message, help: false)
+        @errors << [ message, help ]
+      end
+
+    end
+  end
+end

--- a/lib/shiba/stats/mysql.rb
+++ b/lib/shiba/stats/mysql.rb
@@ -2,12 +2,65 @@ module Shiba
   module Stats
     class Mysql
 
+      def fetch_indexes
+        Shiba.connection.query(sql)
+      end
+
       def sql
         <<-EOL
           select * from information_schema.statistics where
           table_schema = DATABASE()
           order by table_name, if(index_name = 'PRIMARY', '', index_name), seq_in_index
         EOL
+      end
+
+      HEADERS = ["table_catalog", "table_schema", "table_name", "non_unique", "index_schema",
+         "index_name", "seq_in_index", "column_name","collation", "cardinality", "sub_part",
+         "packed", "nullable", "index_type", "comment", "index_comment", "is_visible", "expression"]
+      # def\tzammad_test\tactivity_streams\t0\tzammad_test\tPRIMARY\t1\tid\tA\t0\tNULL\tNULL\t\tBTREE\t\t\tYES\tNULL\n
+      def parse(raw)
+        raw.strip! # avoid whitespace issues
+        headers = raw.lines.first.chomp("\n").split("\t").map(&:downcase)
+        if headers != HEADERS
+          return false
+        end
+
+        records = []
+        raw.each_line do |line|
+          row = line.chomp("\n").split("\t")
+          if row.size != HEADERS.size
+            return false
+          end
+
+          row.map!(&:strip!)
+          records << parse_record(row)
+        end
+
+        records
+      end
+
+      #
+      def parse_record(row)
+        record = Hash[HEADERS.zip(row)]
+
+        record["non_unique"]   = record["non_unique"].to_i
+        record["seq_in_index"] = record["seq_in_index"].to_i
+        record["cardinality"]  = record["cardinality"].to_i
+        record["sub_part"]     = cast_null(record["sub_part"])
+        record["packed"]       = cast_null(record["packed"])
+        record["nullable"]     = cast_bool(record["nullable"])
+        record["is_visible"]   = cast_bool(record["is_visible"])
+        record["expression"]   = cast_null(record["expression"])
+
+        record
+      end
+
+      def cast_null(value)
+        value == "NULL" ? nil : value
+      end
+
+      def cast_bool(value)
+        value == "YES" ? true : false
       end
 
     end

--- a/lib/shiba/stats/mysql.rb
+++ b/lib/shiba/stats/mysql.rb
@@ -1,0 +1,15 @@
+module Shiba
+  module Stats
+    class Mysql
+
+      def sql
+        <<-EOL
+          select * from information_schema.statistics where
+          table_schema = DATABASE()
+          order by table_name, if(index_name = 'PRIMARY', '', index_name), seq_in_index
+        EOL
+      end
+
+    end
+  end
+end

--- a/lib/shiba/stats/mysql.rb
+++ b/lib/shiba/stats/mysql.rb
@@ -20,19 +20,22 @@ module Shiba
       # def\tzammad_test\tactivity_streams\t0\tzammad_test\tPRIMARY\t1\tid\tA\t0\tNULL\tNULL\t\tBTREE\t\t\tYES\tNULL\n
       def parse(raw)
         raw.strip! # avoid whitespace issues
-        headers = raw.lines.first.chomp("\n").split("\t").map(&:downcase)
+        lines       = raw.lines
+        header_line = lines.shift
+        headers =     header_line.chomp("\n").split("\t").map(&:downcase)
+
         if headers != HEADERS
           return false
         end
 
         records = []
-        raw.each_line do |line|
+        lines.each do |line|
           row = line.chomp("\n").split("\t")
           if row.size != HEADERS.size
             return false
           end
 
-          row.map!(&:strip!)
+          row.map!(&:strip)
           records << parse_record(row)
         end
 

--- a/lib/shiba/stats/mysql.rb
+++ b/lib/shiba/stats/mysql.rb
@@ -42,6 +42,17 @@ module Shiba
         records
       end
 
+      def detect_parse_error(file)
+        raw = file.read
+        result = parse(raw)
+
+        if result == false
+          return "Expected first line to be these tab seperated headers:\n#{HEADERS.join("\t")}"
+        end
+
+        return nil
+      end
+
       #
       def parse_record(row)
         record = Hash[HEADERS.zip(row)]

--- a/lib/shiba/stats/postgres.rb
+++ b/lib/shiba/stats/postgres.rb
@@ -17,7 +17,7 @@ module Shiba
         headers     = header_line.split("|").map(&:strip)
 
         if headers != HEADERS
-          return header_line
+          return false
         end
 
         records = []
@@ -31,6 +31,17 @@ module Shiba
 
         records.each { |row| normalize(row) }
         records
+      end
+
+      def detect_parse_error(file)
+        raw = file.read
+        result = parse(raw)
+
+        if result == false
+          return "Expected first line to be these pipe '|' seperated headers:\n#{HEADERS.join(" | ")}"
+        end
+
+        return nil
       end
 
       def parse_record(row)

--- a/lib/shiba/stats/postgres.rb
+++ b/lib/shiba/stats/postgres.rb
@@ -1,0 +1,68 @@
+module Shiba
+  module Stats
+    class Postgres
+
+      def fetch_indexes
+        result = Shiba.connection.query(fetch_indexes_sql)
+        rows = result.to_a.map do |row|
+          # TBD: do better than this, have them return something objecty
+          if row['is_primary'] == "t"
+            row['index_name'] = "PRIMARY"
+            row['non_unique'] = 0
+          elsif row['is_unique']
+            row['non_unique'] = 0
+          end
+
+          if row['numdistinct'].nil?
+            # meaning the table's empty.
+            row['cardinality'] = 0
+          elsif row['numdistinct'] == 0
+            # numdistinct is 0 if there's rows in the table but all values are null
+            row['cardinality'] = 1
+          elsif row['numdistinct'] < 0
+            # postgres talks about either cardinality or selectivity (depending.  what's their heuristic?)
+            # in the same way we do in the yaml file!
+            # if less than zero, it's negative selectivity.
+            row['cardinality'] = -(row['numrows'] * row['numdistinct'])
+          else
+            row['cardinality'] = row['numdistinct']
+          end
+          row
+        end
+
+        #TODO: estimate multi-index column cardinality
+        rows
+      end
+
+      def sql
+        <<-EOL
+          select
+            t.relname as table_name,
+            i.relname as index_name,
+            a.attname as column_name,
+            i.reltuples as numrows,
+            ix.indisunique as is_unique,
+            ix.indisprimary as is_primary,
+            s.n_distinct as numdistinct
+          from pg_namespace p
+          join pg_class t on t.relnamespace = p.oid
+          join pg_index ix on ix.indrelid = t.oid
+          join pg_class i on i.oid = ix.indexrelid
+          join pg_attribute a on a.attrelid = t.oid
+          left join pg_stats s on s.tablename = t.relname
+            AND s.attname = a.attname
+          where
+            p.nspname = 'public'
+            and a.attnum = ANY(ix.indkey)
+            and t.relkind = 'r'
+          order by
+            t.relname,
+            ix.indisprimary desc,
+            i.relname,
+            array_position(ix.indkey, a.attnum)
+        EOL
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This is turning into a thing, but should make pulling stats much more pleasant.

```
Query raw table statistics from the database. Supports gathering statistics from production

Required:
    -s, --server SERVER              The database server. Either 'mysql' or 'postgres'
    -d, --directory APP_DIR          The application directory on the server.

Options:
    -h, --host HOST                  The host to execute the statistics query from. Defaults to localhost.
    -e, --environment ENVIRONMENT    The database environment. Defaults to 'production'.

Advanced options:
        --script                     Print a customizable script instead of executing.
    -f, --file FILE                  Converts the output file from a customized script to usable stats.
        --client CLIENT              The client command to run, defaults to 'rails dbconsole'. Can use 'mysql' and 'psql'.

SSH connection options:
    -p, --proxy PROXY_HOST           The proxy (jump server) to connect to first.

Common options:
        --verbose                    Verbose/debug mode
        --help                       Show this message
        --version                    Show version
```
