### PR TITLE
minimum bar for tablescans

### DIFF
--- a/lib/shiba/explain/checks.rb
+++ b/lib/shiba/explain/checks.rb
@@ -129,6 +129,12 @@ module Shiba
         end
 
         @cost = Shiba::Explain::COST_PER_ROW_READ * rows_read
+
+        # pin fully missed indexes to a 'low' threshold
+        if @access_type == 'access_type_tablescan'
+          @cost = [0.01, @cost].max
+        end
+
         @result.cost += @cost
 
         @tbl_message['cost'] = @cost

--- a/test/explain_test.rb
+++ b/test/explain_test.rb
@@ -29,6 +29,13 @@ describe "Explain" do
     it_includes_tag("access_type_tablescan")
   end
 
+  describe "a table scan on a small table" do
+    let(:sql) { "select * from organizations" }
+    it "should report as at least 10ms" do
+      assert_operator(0.010, :<=, explain.cost)
+    end
+  end
+
   describe "with a SELECT * / limit 1" do
     let(:sql) { "select * from users limit 1" }
     it_includes_tag("limited_scan")


### PR DESCRIPTION
This definitely blows up analysis time, also inflates zammad to 75
queries (from 20), but it does do the thing.  Probably should make this
option smarter in the future or configurable.