### PR TITLE
Attempt to pull commit SHA from alternative Travis ENV

### DIFF
--- a/lib/shiba/review/cli.rb
+++ b/lib/shiba/review/cli.rb
@@ -271,7 +271,7 @@ module Shiba
       end
 
       def ci_branch
-        ENV['TRAVIS_PULL_REQUEST_SHA'] || ENV['CIRCLE_SHA1']
+        ENV['TRAVIS_PULL_REQUEST_SHA'] || ENV['TRAVIS_COMMIT'] || ENV['CIRCLE_SHA1']
       end
 
       def ci_pull_request


### PR DESCRIPTION
If the test run on Travis-CI is not directly from a pull request then shiba will fail to find the branch commit hash. Therefore we also inspect `ENV['TRAVIS_COMMIT']` in order to determine the git commit to test.

Fixes #32